### PR TITLE
Revise parameter-group module

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -20,9 +20,6 @@ jobs:
 
       - name: terraform setup
         uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: 0.12.29
-      #   cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
 #     TODO: This step duplicates work done by the Makefile.
 #     - name: check terraform formatting

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rds-parameter-group module
+# rds-parameter-group
 
 [![Terraform actions status](https://github.com/techservicesillinois/terraform-aws-rds-parameter-group/workflows/terraform/badge.svg)](https://github.com/techservicesillinois/terraform-aws-rds-parameter-group/actions)
 
@@ -10,18 +10,21 @@ Manage an RDS parameter group.
 module "rds-parameter-group" {
   source = "git@github.com:techservicesillinois/terraform-aws-rds-parameter-group"
 
-  name = "my-db"
-  family = "oracle-ee-12.1"
+  # Family must match RDS instance's engine version.
+  family = "mariadb10.6"
+
+  # Prefix for parameter group name.
+  prefix = "authman"
+
   parameter = [
     {
-      name  = "open_cursors"
-      value = 2000
-      apply_method = "pending-reboot"
+      name  = "character_set_client"
+      value = "utf8"
     },
+
     {
-      name  = "processes"
-      value = 300
-      apply_method = "pending-reboot"
+      name  = "character_set_connection"
+      value = "utf8"
     }
   ]
 }
@@ -32,20 +35,30 @@ Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DB parameter group. If omitted, Terraform will assign a random, unique name. 
+* `family` - (Required) Parameter group family (engine and version)"
 
-* `family` - (Required) The family of the DB parameter group. 
+* `parameter` - (Optional) List containing map of parameters to include in the parameter group. Note that parameters differ from one RDS family to another. A full list of all parameters can be discovered via the AWS command line interface by running `aws rds describe-db-parameters` after creation of a parameter group.
 
-* `parameter` - (Optional) A list of DB parameters to apply. Note that parameters may differ from a family to an other. Full list of all parameters can be discovered via aws rds describe-db-parameters after initial creation of the group. 
+* `prefix` - (Required) Prefix for parameter group name. The full name is generated from the prefix and the family. The prefix may contain only letters, digits, or hyphens. See [Working with DB parameter groups](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithDBInstanceParamGroups.html) for additional restrictions.
 
-* `tags` - (Optional) A mapping of tags to assign to the resource. 
+* `tags` - (Optional) Tags to be applied to resources where supported.
 
+`parameter`
+----------
+
+A `parameter` block consists of a list containing one or more objects, each of which may contain the following attributes:
+
+* `apply_method` - (Optional) XXX. The valid values consist of `immediate` or `pending-reboot`."immediate" (default), or "pending-reboot". Some engines can't apply some parameters without a reboot, and you will need to specify "pending-reboot" here.
+
+* `autoscale_scale_down` - (Optional) The name of the autoscaling policy for scale down. Default name is ('service name'-down)
+
+* `adjustment_type` - (Required) Specifies whether the adjustment is an absolute number or a percentage of the current capacity. Valid values are ChangeInCapacity, ExactCapacity, and PercentChangeInCapacity.
 
 Attributes Reference
 --------------------
 
 The following attributes are exported:
 
-* `id` - The db parameter group name. 
+* `arn` - The Amazon Resource Name of the parameter group.
 
-* `name` - The name of the db parameter group. 
+* `name` - The name of the db parameter group.

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,21 @@
+locals {
+  pg_name = format("%s-%s", var.prefix, replace(var.family, ".", "-"))
+}
+
 resource "aws_db_parameter_group" "default" {
-  name        = var.name
-  description = "${var.name} parameter group"
+  name        = local.pg_name
+  description = format("%s parameter group", local.pg_name)
   family      = var.family
+
   dynamic "parameter" {
     for_each = var.parameter
     content {
-      apply_method = lookup(parameter.value, "apply_method", "pending-reboot")
-      name         = parameter.value["name"]
-      value        = parameter.value["value"]
+      apply_method = parameter.value.apply_method
+      name         = parameter.value.name
+      value        = parameter.value.value
     }
   }
-  tags = merge({ "Name" = var.name }, var.tags)
+  tags = merge({ Name = var.prefix }, var.tags)
 
   lifecycle {
     create_before_destroy = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
-output "id" {
-  value = aws_db_parameter_group.default.id
+output "arn" {
+  value = aws_db_parameter_group.default.arn
 }
 
 output "name" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,19 +1,29 @@
-variable "name" {
-  description = "Name of the parameter group"
-}
-
 variable "family" {
-  description = "The family of the parameter group"
+  description = "Parameter group family (engine and version)"
 }
 
 variable "parameter" {
-  description = "List containing map of parameters to apply"
-  type        = list(map(any))
-  default     = []
+  description = "List containing parameters to include in the parameter group"
+  type = list(object({
+    apply_method = optional(string, "pending-reboot")
+    name         = string
+    value        = string
+  }))
+
+  # Validate subnet_type (if specified).
+
+  validation {
+    condition     = alltrue([for p in var.parameter : contains(["immediate", "pending-reboot"], p.apply_method)])
+    error_message = "The 'apply_method' specified in the 'parameter' block is not one of the valid values 'immediate' or 'pending_reboot'."
+  }
+}
+
+variable "prefix" {
+  description = "Prefix for parameter group name"
 }
 
 variable "tags" {
-  description = "Map of tags to assign to resources"
+  description = "Tags to be applied to resources where supported"
   type        = map(string)
   default     = {}
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
*   Use Terraform objects and add validation.

*   Bake family name into parameter group name to simplify version
    migration. The `name` input variable thus becomes `prefix`.

*   Bump required_version to 1.3.

*   Clean up variable descriptions.

*   Revise documentation.

*   Replace redundant `id` output with `arn`.